### PR TITLE
devise/ 配下ではなく users/ 配下のコントローラを見るようにroutes.rb を修正

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,9 +12,10 @@ Rails.application.routes.draw do
   get 'home/edit'
 
   devise_for :users, controllers: {
+    passwords: 'users/passwords',
+    registrations: 'users/registrations',
     sessions: 'users/sessions'
   }
-	
   get 'rails/show'
 
   get 'rails/list'


### PR DESCRIPTION
routes の設定を忘れていて devise 配下のコントローラを見てしまっていました。
そのため users/~~~ を見るように修正しました。